### PR TITLE
Sort

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/RobotsAndPencils/go-swaggerLite/markup"
@@ -97,6 +98,9 @@ func generateSwaggerDocs(parser *parser.Parser) {
 		apiDescriptions.Write(json)
 		apiDescriptions.WriteString("`,")
 	}
+
+	// sort the apiRefs to ensure consistent output
+	sort.Sort(ListingByApiRefPath(parser.Listing.Apis))
 
 	doc := strings.Replace(generatedFileTemplate, "{{resourceListing}}", "`"+string(getResourceListingJson(parser.Listing))+"`", -1)
 	doc = strings.Replace(doc, "{{apiDescriptions}}", "map[string]string{"+apiDescriptions.String()+"}", -1)
@@ -187,3 +191,10 @@ func sortedApiDeclarationKeys(m map[string]*parser.ApiDeclaration) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+// sort the ApiRef's in-place
+type ListingByApiRefPath []*parser.ApiRef
+
+func (a ListingByApiRefPath) Len() int           { return len(a) }
+func (a ListingByApiRefPath) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ListingByApiRefPath) Less(i, j int) bool { return a[i].Path < a[j].Path }

--- a/generator.go
+++ b/generator.go
@@ -98,7 +98,7 @@ func generateSwaggerDocs(parser *parser.Parser) {
 		apiDescriptions.WriteString("`,")
 	}
 
-	doc := strings.Replace(generatedFileTemplate, "{{resourceListing}}", "`"+string(parser.GetResourceListingJson())+"`", -1)
+	doc := strings.Replace(generatedFileTemplate, "{{resourceListing}}", "`"+string(getResourceListingJson(parser.Listing))+"`", -1)
 	doc = strings.Replace(doc, "{{apiDescriptions}}", "map[string]string{"+apiDescriptions.String()+"}", -1)
 	doc = strings.Replace(doc, "{{generagedPackage}}", *generatedPackage, -1)
 
@@ -166,4 +166,12 @@ func main() {
 		log.Fatalf("Invalid -format specified. Must be one of %v.", AVAILABLE_FORMATS)
 	}
 
+}
+
+func getResourceListingJson(listing *parser.ResourceListing) []byte {
+	json, err := json.MarshalIndent(listing, "", "    ")
+	if err != nil {
+		log.Fatalf("Can not serialise ResourceListing to JSON: %v\n", err)
+	}
+	return json
 }

--- a/generator.go
+++ b/generator.go
@@ -86,11 +86,11 @@ func generateSwaggerDocs(parser *parser.Parser) {
 	defer fd.Close()
 
 	var apiDescriptions bytes.Buffer
-	for apiKey, apiDescription := range parser.TopLevelApis {
+	for _, apiKey := range sortedApiDeclarationKeys(parser.TopLevelApis) {
 		apiDescriptions.WriteString("\"" + apiKey + "\":")
 
 		apiDescriptions.WriteString("`")
-		json, err := json.MarshalIndent(apiDescription, "", "    ")
+		json, err := json.MarshalIndent(parser.TopLevelApis[apiKey], "", "    ")
 		if err != nil {
 			log.Fatalf("Can not serialise []ApiDescription to JSON: %v\n", err)
 		}
@@ -174,4 +174,16 @@ func getResourceListingJson(listing *parser.ResourceListing) []byte {
 		log.Fatalf("Can not serialise ResourceListing to JSON: %v\n", err)
 	}
 	return json
+}
+
+// returns sorted map keys, used for looping items in the map
+func sortedApiDeclarationKeys(m map[string]*parser.ApiDeclaration) []string {
+	keys := make([]string, len(m))
+	i := 0
+	for key, _ := range m {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"encoding/json"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -80,22 +79,6 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 		}
 	}
 	return nil
-}
-
-func (parser *Parser) GetResourceListingJson() []byte {
-	json, err := json.MarshalIndent(parser.Listing, "", "    ")
-	if err != nil {
-		log.Fatalf("Can not serialise ResourceListing to JSON: %v\n", err)
-	}
-	return json
-}
-
-func (parser *Parser) GetApiDescriptionJson() []byte {
-	json, err := json.MarshalIndent(parser.TopLevelApis, "", "    ")
-	if err != nil {
-		log.Fatalf("Can not serialise []ApiDescription to JSON: %v\n", err)
-	}
-	return json
 }
 
 func (parser *Parser) CheckRealPackagePath(packagePath string) string {


### PR DESCRIPTION
#### What's this PR do?
- Adds alpha sort to Api list (by path) so apis are properly sorted in the display.
- ApiDeclarations is a map and since a Go map item order is random, the generatedSwaggerSpec.go was likely to be different on each run of the tool even if the api being analyzed did not contain material changes. Annoying if the generated file is in source control. Loop through declarations during generation is now alpha-sorted by map key.
