### PR TITLE
Support vendor dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Quick Start Guide
     * -apiPackage  - package with API controllers implementation
     * -mainApiFile - main API file. We will look for "General API info" in this file. If the mainApiFile command-line switch is left blank, then main.go is assumed (in the location specified by apiPackage).
     * -basePath    - Your API URL. Test requests will be sent to this URL
+    * -packageExclusionList - Comma delimited list of packages to report-continue vs. fail when not found
 
 4. This will generate a `generatedSwaggerSpec.go` in `package main`. In this a `swaggerApiHandler` function is expossed that takes a URI path prefeix (to strip off) and returns a `http.HandlerFunc`. You might map this via a Gorilla Mux router like:
 

--- a/generator.go
+++ b/generator.go
@@ -27,6 +27,7 @@ var basePath = flag.String("basePath", "", "Web service base path")
 var outputFormat = flag.String("format", "go", "Output format type for the generated files: "+AVAILABLE_FORMATS)
 var output = flag.String("output", "generatedSwaggerSpec.go", "The opitonal name of the output file to be generated")
 var generatedPackage = flag.String("package", "main", "The opitonal package name of the output file to be generated")
+var packageExclusionList = flag.String("packageExclusionList", "", "Comma delimited list of packages to report-continue vs. fail when not found")
 
 var generatedFileTemplate = `package {{generagedPackage}}
 //This file is generated automatically. Do not edit it manually.
@@ -114,6 +115,7 @@ func InitParser() *parser.Parser {
 
 	parser.ApiPackage = *apiPackage
 	parser.BasePath = *basePath
+	parser.PackageExclusionList = exclusions(*packageExclusionList)
 	parser.IsController = IsController
 
 	parser.TypesImplementingMarshalInterface["NullString"] = "string"
@@ -191,6 +193,11 @@ func sortedApiDeclarationKeys(m map[string]*parser.ApiDeclaration) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func exclusions(exclusionStr string) []string {
+	exclusionStr = strings.Replace(exclusionStr, " ", "", -1)
+	return strings.Split(exclusionStr, ",")
 }
 
 // sort the ApiRef's in-place

--- a/generator.go
+++ b/generator.go
@@ -112,6 +112,7 @@ func generateSwaggerDocs(parser *parser.Parser) {
 func InitParser() *parser.Parser {
 	parser := parser.NewParser()
 
+	parser.ApiPackage = *apiPackage
 	parser.BasePath = *basePath
 	parser.IsController = IsController
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -219,6 +219,11 @@ func (parser *Parser) ScanPackages(packages []string) []string {
 						return nil
 					}
 
+					// Ignore anything under a ./.git directory
+					if idx := strings.Index(path, pkgRealPath+"/.git/"); idx != -1 {
+						return nil
+					}
+
 					// Ignore anything under a ./vendor directory
 					if idx := strings.Index(path, pkgRealPath+"/vendor/"); idx != -1 {
 						return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,6 +23,7 @@ type Parser struct {
 	BasePath                          string
 	IsController                      func(*ast.FuncDecl) bool
 	TypesImplementingMarshalInterface map[string]string
+	ApiPackage                        string
 }
 
 func NewParser() *Parser {
@@ -96,9 +97,15 @@ func (parser *Parser) CheckRealPackagePath(packagePath string) string {
 	pkgRealpath := ""
 	gopathsList := filepath.SplitList(gopath)
 	for _, path := range gopathsList {
-		if evalutedPath, err := filepath.EvalSymlinks(filepath.Join(path, "src", packagePath)); err == nil {
-			if _, err := os.Stat(evalutedPath); err == nil {
-				pkgRealpath = evalutedPath
+		if vendorPath, err := filepath.EvalSymlinks(filepath.Join(path, "src", parser.ApiPackage, "vendor", packagePath)); err == nil {
+			if _, err := os.Stat(vendorPath); err == nil {
+				pkgRealpath = vendorPath
+				break
+			}
+		}
+		if goPath, err := filepath.EvalSymlinks(filepath.Join(path, "src", packagePath)); err == nil {
+			if _, err := os.Stat(goPath); err == nil {
+				pkgRealpath = goPath
 				break
 			}
 		}


### PR DESCRIPTION
#### What's this PR do?
- Add support for resolving package dependencies located in `/vendor`.
- Exclude searching files in `.git` dir
- Add packageExclusionList flag to exclude packages whose errors are inconsequential and outside of the developers control (golang.org/x/net/context is the specific case)
#### How should this be manually tested?
1. `go install`
2. From the root of a project using go-swaggerLite, run something `go-swaggerLite -apiPackage="github.com/{your org}/{your package}" - output="apispec/generatedSwaggerSpec.go" -package="apispec" -packageExclusionList="{the missing package}"
3. If your project uses golang.org/x/net/context package, the exclusion list can be tested as well.
